### PR TITLE
Fix Issuer Validation inside Response

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "ext-zlib": "*",
         "robrichards/xmlseclibs": "^3.0",
         "php": "^7.1 || ^8.0",
-        "psr/log": ">= 1.1.4"
+        "psr/log": "1.1.4 || ^3.0"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "*",

--- a/src/Spid/Interfaces/ResponseInterface.php
+++ b/src/Spid/Interfaces/ResponseInterface.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace Italia\Spid\Spid\Interfaces;
 
+use DOMDocument;
+
 interface ResponseInterface
 {
     // Validates a received response.
     // Throws exceptions on missing or invalid values.
     // returns false if response code is not success
     // returns true otherwise
-    public function validate($xml, $hasAssertion): bool;
+    public function validate(DOMDocument $xml, $hasAssertion): bool;
 }

--- a/src/Spid/Saml/In/LogoutRequest.php
+++ b/src/Spid/Saml/In/LogoutRequest.php
@@ -2,6 +2,7 @@
 
 namespace Italia\Spid\Spid\Saml\In;
 
+use DOMDocument;
 use Exception;
 use Italia\Spid\Spid\Interfaces\ResponseInterface;
 use Italia\Spid\Spid\Saml;
@@ -18,7 +19,7 @@ class LogoutRequest implements ResponseInterface
     /**
      * @throws Exception
      */
-    public function validate($xml, $hasAssertion): bool
+    public function validate(DOMDocument $xml, $hasAssertion): bool
     {
         $root = $xml->getElementsByTagName('LogoutRequest')->item(0);
 

--- a/src/Spid/Saml/In/LogoutResponse.php
+++ b/src/Spid/Saml/In/LogoutResponse.php
@@ -2,6 +2,7 @@
 
 namespace Italia\Spid\Spid\Saml\In;
 
+use DOMDocument;
 use Exception;
 use Italia\Spid\Spid\Interfaces\ResponseInterface;
 
@@ -10,7 +11,7 @@ class LogoutResponse implements ResponseInterface
     /**
      * @throws Exception
      */
-    public function validate($xml, $hasAssertion): bool
+    public function validate(DOMDocument $xml, $hasAssertion): bool
     {
         $root = $xml->getElementsByTagName('LogoutResponse')->item(0);
 

--- a/src/Spid/Saml/In/Response.php
+++ b/src/Spid/Saml/In/Response.php
@@ -79,7 +79,10 @@ class Response implements ResponseInterface
                 "Invalid Issuer attribute, expected {$_SESSION['idpEntityId']} but received " .
                 $issuer->item(0)->nodeValue
             );
-        } elseif ($issuer->item(0)->getAttribute('Format') != $samlUrn . 'nameid-format:entity') {
+        } elseif (
+            $issuer->item(0)->hasAttribute('Format')
+            && $issuer->item(0)->getAttribute('Format') != $samlUrn . 'nameid-format:entity'
+        ) {
             $logger->logAndThrow(
                 $xml,
                 "Invalid Issuer attribute, expected '{$samlUrn}nameid-format:entity' but received " .

--- a/src/Spid/Saml/In/Response.php
+++ b/src/Spid/Saml/In/Response.php
@@ -20,7 +20,7 @@ class Response implements ResponseInterface
     /**
      * @throws SpidException
      */
-    public function validate($xml, $hasAssertion): bool
+    public function validate(DOMDocument $xml, $hasAssertion): bool
     {
         $logger = $this->saml->getLogger();
 


### PR DESCRIPTION
Ensures that the element `Issuer` inside a `Response` has the correct format only when provided, as it is optional.

From spid technical rules on page 12 (regarding `Response` element):
> deve essere presente l'elemento `Issuer` a indicare l'entityID dell'entità emittente, cioè l'Identity Provider stesso; 
> L'attributo format deve essere omesso o assumere valore `urn:oasis:names:tc:SAML:2.0:nameid-format:entity`;

On top of that, enforce the `xml` parameter in `ResponseInterface` to be a `DOMDocument`